### PR TITLE
Use local time zone for all-day events

### DIFF
--- a/Apps/GCal_Search.groovy
+++ b/Apps/GCal_Search.groovy
@@ -1,4 +1,4 @@
-def appVersion() { return "2.0.0" }
+def appVersion() { return "2.0.1" }
 /**
  *  GCal Search
  *  https://raw.githubusercontent.com/HubitatCommunity/Google_Calendar_Search/main/Apps/GCal_Search.groovy
@@ -374,7 +374,7 @@ def getNextEvents(watchCalendar, search, endTimePreference) {
                     if (event.start.containsKey('date')) {
                         eventAllDay = true
                         def sdf = new java.text.SimpleDateFormat("yyyy-MM-dd")
-                        sdf.setTimeZone(TimeZone.getTimeZone(queryResponse.timeZone))            	
+                        sdf.setTimeZone(location.timeZone)            	
                         eventStartTime = sdf.parse(event.start.date)
                         eventEndTime = new Date(sdf.parse(event.end.date).time - 60)
                     } else {


### PR DESCRIPTION
When processing an all-day event, use the local time zone of the hub, rather than the time zone of the calendar, to ensure that the triggers are scheduled at local midnight.